### PR TITLE
fix a small typo for requirements installation in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The information includes:
 # Usage
 Note: You must use python3.6 or greater due to the use of "f" strings
 
-1. `pip3 install -r requriments.txt`
+1. `pip3 install -r requirements.txt`
 2. `python3 main.py --username USERNAME`
 
 


### PR DESCRIPTION
Hello! Thanks for making this. I was starting to use it and realized that there's a small typo in the README. Thought I'd just make a quick PR to fix in case anyone else runs into it. 

Again, thanks for this work!